### PR TITLE
BugFix: Call Join a second time after a disconnect

### DIFF
--- a/Phoenix/Channel.cs
+++ b/Phoenix/Channel.cs
@@ -66,9 +66,8 @@ namespace Phoenix {
 
 			var payload = parameters == null ? null : JObject.FromObject(parameters);
 			var message = MakeMessage(Message.OutBoundEvent.phx_join, null, payload);
+			joinRef = message.@ref;
 			var push = Push(message, timeout);
-
-			joinRef = push.message.@ref;
 
 			return push;
 		}


### PR DESCRIPTION
Hi I encountered a strange issue when you try to join a channel again after a disconnect.

**Problem:**
When Join() is called in a channel the joinRef is set after the Push(Message message, TimeSpan? timeout) method. This causes a problem because you can receive the join_reply before the joinRef is set. In this case the Channel.OnReply() method doesn't recognize the reply as join_reply and removes the push from the activePushes Dictionary but afterwards the joinRef will be set.
If you now disconnect from the channel and try to connect again, the Channel.Rejoin() method will be called and executes the line "joinPush.reply = null;" because the joinRef was not null. The causes the exception because the activePushes dictionary is empty but the joinRef is not null.

**Solution:** 
Set the joinRef before the Push(Message message, TimeSpan? timeout) method is called in Channel.Join(...).