### PR TITLE
Test Case for #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ TestResult.xml
 .idea/
 *.sln.iml
 
-
+# Visual Studio 
+.vs/
+packages/

--- a/Phoenix/Phoenix.csproj
+++ b/Phoenix/Phoenix.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Phoenix</RootNamespace>
     <AssemblyName>Phoenix</AssemblyName>
-    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -29,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Phoenix/Socket.cs
+++ b/Phoenix/Socket.cs
@@ -161,13 +161,13 @@ namespace Phoenix {
 
 			CancelHeartbeat();
 			TriggerChannelError("socket disconnect");
-            
+			
 			websocket.Close(code, reason);
 
-            // disables callbacks
-            state = State.Closed;
+			// disables callbacks
+			state = State.Closed;
 
-            websocket = null;
+			websocket = null;
 		}
 
 		// params - The params to send when connecting, for example `{user_id: userToken}`

--- a/Phoenix/Socket.cs
+++ b/Phoenix/Socket.cs
@@ -161,12 +161,13 @@ namespace Phoenix {
 
 			CancelHeartbeat();
 			TriggerChannelError("socket disconnect");
-
-			// disables callbacks
-			state = State.Closed;
-
+            
 			websocket.Close(code, reason);
-			websocket = null;
+
+            // disables callbacks
+            state = State.Closed;
+
+            websocket = null;
 		}
 
 		// params - The params to send when connecting, for example `{user_id: userToken}`

--- a/PhoenixTests/IntegrationTests.cs
+++ b/PhoenixTests/IntegrationTests.cs
@@ -9,70 +9,7 @@ using WebSocketSharp;
 
 namespace PhoenixTests {
 
-	public sealed class WebsocketSharpAdapter: IWebsocket {
-
-		private readonly WebSocket ws;
-		private readonly WebsocketConfiguration config;
-
-
-		public WebsocketSharpAdapter(WebSocket ws, WebsocketConfiguration config) {
-			
-			this.ws = ws;
-			this.config = config;
-
-			ws.OnOpen += OnWebsocketOpen;
-			ws.OnClose += OnWebsocketClose;
-			ws.OnError += OnWebsocketError;
-			ws.OnMessage += OnWebsocketMessage;
-		}
-
-
-		#region IWebsocket methods
-
-		public void Connect() {
-			ws.Connect();
-		}
-
-		public void Send(string message) {
-			ws.Send(message);
-		}
-
-		public void Close(ushort? code = null, string message = null) {
-			ws.Close();
-		}
-
-		#endregion
-
-
-		#region websocketsharp callbacks
-
-		public void OnWebsocketOpen(object sender, EventArgs args) {
-			config.onOpenCallback(this);
-		}
-
-		public void OnWebsocketClose(object sender, CloseEventArgs args) {
-			config.onCloseCallback(this, args.Code, args.Reason);
-		}
-
-		public void OnWebsocketError(object sender, ErrorEventArgs args) {
-			config.onErrorCallback(this, args.Message);
-		}
-
-		public void OnWebsocketMessage(object sender, MessageEventArgs args) {
-			config.onMessageCallback(this, args.Data);
-		}
-
-		#endregion
-	}
-
-	public sealed class WebsocketSharpFactory: IWebsocketFactory {
-
-		public IWebsocket Build(WebsocketConfiguration config) {
-
-			var socket = new WebSocket(config.uri.AbsoluteUri);
-			return new WebsocketSharpAdapter(socket, config);
-		}
-	}
+	
 
 	public sealed class BasicLogger : ILogger {
 		
@@ -86,18 +23,18 @@ namespace PhoenixTests {
 	}
 
 
-	[TestFixture()]
-	public class IntegrationTests {
+    [TestFixture()]
+    public class IntegrationTests {
 
-		private const int networkDelay = 500 /* ms */;
-
-		[Test()]
-		public void IntegrationTest() {
+        private const int networkDelay = 500 /* ms */;
+        private const string host = "phoenix-integration-tester.herokuapp.com";
+        
+        [Test()]
+		public void GeneralIntegrationTest() {
 
 			/// 
 			/// setup
 			/// 
-			var host = "localhost:4000";
 			var address = string.Format("http://{0}/api/health-check", host);
 
 			// heroku health check
@@ -112,13 +49,15 @@ namespace PhoenixTests {
 			List<String> onMessageData = new List<string>();
 			Socket.OnMessageDelegate onMessageCallback = m => onMessageData.Add(m);
 
-			// connecting is synchronous as implemented above
-			var socketFactory = new WebsocketSharpFactory();
-			var socket = new Socket(socketFactory, new Socket.Options {
-				channelRejoinInterval = TimeSpan.FromMilliseconds(200),
-				logger = new BasicLogger()
-			});
-			socket.OnOpen += onOpenCallback;
+            // connecting is synchronous as implemented above
+            var socketFactory = new WebsocketSharpFactory();
+            var socket = new Socket(socketFactory, new Socket.Options
+            {
+                channelRejoinInterval = TimeSpan.FromMilliseconds(200),
+                logger = new BasicLogger()
+            });
+
+            socket.OnOpen += onOpenCallback;
 			socket.OnMessage += onMessageCallback;
 
 			socket.Connect(string.Format("ws://{0}/socket", host), null);
@@ -270,6 +209,68 @@ namespace PhoenixTests {
 			Assert.That(() => newCloseMessage != null, Is.True.After(networkDelay, 10));
 			Assert.IsNull(pushMessage); // ignored
 		}
-	}
+
+        [Test()]
+        public void MultipleJoinIntegrationTest()
+        {
+            var onOpenCount = 0;
+            Socket.OnOpenDelegate onOpenCallback = () => onOpenCount++;
+            Socket.OnClosedDelegate onClosedCallback = (code, message) => onOpenCount--;
+
+            List<String> onMessageData = new List<string>();
+            Socket.OnMessageDelegate onMessageCallback = m => onMessageData.Add(m);
+
+            var socketFactory = new DotNetWebSocketFactory();
+            var socket = new Socket(socketFactory, new Socket.Options
+            {
+                channelRejoinInterval = TimeSpan.FromMilliseconds(200),
+                logger = new BasicLogger()
+            });
+
+            socket.OnOpen += onOpenCallback;
+            socket.OnClose += onClosedCallback;
+            socket.OnMessage += onMessageCallback;
+
+            socket.Connect(string.Format("ws://{0}/socket", host), null);
+            Assert.IsTrue(socket.state == Socket.State.Open);
+            Assert.AreEqual(1, onOpenCount);
+
+            Reply? joinOkReply = null;
+            Reply? joinErrorReply = null;
+            Message afterJoinMessage = null;
+            Message closeMessage = null;
+            Message errorMessage = null;
+
+            //Try to join for the first time
+            var param = new Dictionary<string, object> {
+                { "auth", "doesn't matter" },
+            };
+
+            var roomChannel = socket.MakeChannel("tester:phoenix-sharp");
+            roomChannel.On(Message.InBoundEvent.phx_close, m => closeMessage = m);
+            roomChannel.On(Message.InBoundEvent.phx_error, m => errorMessage = m);
+            roomChannel.On("after_join", m => afterJoinMessage = m);
+
+            roomChannel.Join(param)
+                .Receive(Reply.Status.Ok, r => joinOkReply = r)
+                .Receive(Reply.Status.Error, r => joinErrorReply = r);
+
+            Assert.That(() => joinOkReply.HasValue, Is.True.After(networkDelay, 10));
+            Assert.IsNull(joinErrorReply);
+
+            Assert.That(() => afterJoinMessage != null, Is.True.After(networkDelay, 10));
+            Assert.AreEqual("Welcome!", afterJoinMessage.payload["message"].Value<string>());
+
+            Assert.AreEqual(Channel.State.Joined, roomChannel.state);
+
+            socket.Disconnect(null, null);
+
+            Assert.AreEqual(Socket.State.Closed, socket.state);
+
+            socket.Connect(string.Format("ws://{0}/socket", host), null);
+            Assert.IsTrue(socket.state == Socket.State.Open);
+            Assert.AreEqual(1, onOpenCount);
+        }
+    }
 }
 

--- a/PhoenixTests/IntegrationTests.cs
+++ b/PhoenixTests/IntegrationTests.cs
@@ -23,13 +23,13 @@ namespace PhoenixTests {
 	}
 
 
-    [TestFixture()]
-    public class IntegrationTests {
+	[TestFixture()]
+	public class IntegrationTests {
 
-        private const int networkDelay = 500 /* ms */;
-        private const string host = "phoenix-integration-tester.herokuapp.com";
-        
-        [Test()]
+		private const int networkDelay = 500 /* ms */;
+		private const string host = "phoenix-integration-tester.herokuapp.com";
+		
+		[Test()]
 		public void GeneralIntegrationTest() {
 
 			/// 
@@ -49,15 +49,15 @@ namespace PhoenixTests {
 			List<String> onMessageData = new List<string>();
 			Socket.OnMessageDelegate onMessageCallback = m => onMessageData.Add(m);
 
-            // connecting is synchronous as implemented above
-            var socketFactory = new WebsocketSharpFactory();
-            var socket = new Socket(socketFactory, new Socket.Options
-            {
-                channelRejoinInterval = TimeSpan.FromMilliseconds(200),
-                logger = new BasicLogger()
-            });
+			// connecting is synchronous as implemented above
+			var socketFactory = new WebsocketSharpFactory();
+			var socket = new Socket(socketFactory, new Socket.Options
+			{
+				channelRejoinInterval = TimeSpan.FromMilliseconds(200),
+				logger = new BasicLogger()
+			});
 
-            socket.OnOpen += onOpenCallback;
+			socket.OnOpen += onOpenCallback;
 			socket.OnMessage += onMessageCallback;
 
 			socket.Connect(string.Format("ws://{0}/socket", host), null);
@@ -210,67 +210,67 @@ namespace PhoenixTests {
 			Assert.IsNull(pushMessage); // ignored
 		}
 
-        [Test()]
-        public void MultipleJoinIntegrationTest()
-        {
-            var onOpenCount = 0;
-            Socket.OnOpenDelegate onOpenCallback = () => onOpenCount++;
-            Socket.OnClosedDelegate onClosedCallback = (code, message) => onOpenCount--;
+		[Test()]
+		public void MultipleJoinIntegrationTest()
+		{
+			var onOpenCount = 0;
+			Socket.OnOpenDelegate onOpenCallback = () => onOpenCount++;
+			Socket.OnClosedDelegate onClosedCallback = (code, message) => onOpenCount--;
 
-            List<String> onMessageData = new List<string>();
-            Socket.OnMessageDelegate onMessageCallback = m => onMessageData.Add(m);
+			List<String> onMessageData = new List<string>();
+			Socket.OnMessageDelegate onMessageCallback = m => onMessageData.Add(m);
 
-            var socketFactory = new DotNetWebSocketFactory();
-            var socket = new Socket(socketFactory, new Socket.Options
-            {
-                channelRejoinInterval = TimeSpan.FromMilliseconds(200),
-                logger = new BasicLogger()
-            });
+			var socketFactory = new DotNetWebSocketFactory();
+			var socket = new Socket(socketFactory, new Socket.Options
+			{
+				channelRejoinInterval = TimeSpan.FromMilliseconds(200),
+				logger = new BasicLogger()
+			});
 
-            socket.OnOpen += onOpenCallback;
-            socket.OnClose += onClosedCallback;
-            socket.OnMessage += onMessageCallback;
+			socket.OnOpen += onOpenCallback;
+			socket.OnClose += onClosedCallback;
+			socket.OnMessage += onMessageCallback;
 
-            socket.Connect(string.Format("ws://{0}/socket", host), null);
-            Assert.IsTrue(socket.state == Socket.State.Open);
-            Assert.AreEqual(1, onOpenCount);
+			socket.Connect(string.Format("ws://{0}/socket", host), null);
+			Assert.IsTrue(socket.state == Socket.State.Open);
+			Assert.AreEqual(1, onOpenCount);
 
-            Reply? joinOkReply = null;
-            Reply? joinErrorReply = null;
-            Message afterJoinMessage = null;
-            Message closeMessage = null;
-            Message errorMessage = null;
+			Reply? joinOkReply = null;
+			Reply? joinErrorReply = null;
+			Message afterJoinMessage = null;
+			Message closeMessage = null;
+			Message errorMessage = null;
 
-            //Try to join for the first time
-            var param = new Dictionary<string, object> {
-                { "auth", "doesn't matter" },
-            };
+			//Try to join for the first time
+			var param = new Dictionary<string, object> {
+				{ "auth", "doesn't matter" },
+			};
 
-            var roomChannel = socket.MakeChannel("tester:phoenix-sharp");
-            roomChannel.On(Message.InBoundEvent.phx_close, m => closeMessage = m);
-            roomChannel.On(Message.InBoundEvent.phx_error, m => errorMessage = m);
-            roomChannel.On("after_join", m => afterJoinMessage = m);
+			var roomChannel = socket.MakeChannel("tester:phoenix-sharp");
+			roomChannel.On(Message.InBoundEvent.phx_close, m => closeMessage = m);
+			roomChannel.On(Message.InBoundEvent.phx_error, m => errorMessage = m);
+			roomChannel.On("after_join", m => afterJoinMessage = m);
 
-            roomChannel.Join(param)
-                .Receive(Reply.Status.Ok, r => joinOkReply = r)
-                .Receive(Reply.Status.Error, r => joinErrorReply = r);
+			roomChannel.Join(param)
+				.Receive(Reply.Status.Ok, r => joinOkReply = r)
+				.Receive(Reply.Status.Error, r => joinErrorReply = r);
 
-            Assert.That(() => joinOkReply.HasValue, Is.True.After(networkDelay, 10));
-            Assert.IsNull(joinErrorReply);
+			Assert.That(() => joinOkReply.HasValue, Is.True.After(networkDelay, 10));
+			Assert.IsNull(joinErrorReply);
 
-            Assert.That(() => afterJoinMessage != null, Is.True.After(networkDelay, 10));
-            Assert.AreEqual("Welcome!", afterJoinMessage.payload["message"].Value<string>());
+			Assert.That(() => afterJoinMessage != null, Is.True.After(networkDelay, 10));
+			Assert.AreEqual("Welcome!", afterJoinMessage.payload["message"].Value<string>());
 
-            Assert.AreEqual(Channel.State.Joined, roomChannel.state);
+			Assert.AreEqual(Channel.State.Joined, roomChannel.state);
 
-            socket.Disconnect(null, null);
+			socket.Disconnect(null, null);
 
-            Assert.AreEqual(Socket.State.Closed, socket.state);
+			Assert.AreEqual(Socket.State.Closed, socket.state);
 
-            socket.Connect(string.Format("ws://{0}/socket", host), null);
-            Assert.IsTrue(socket.state == Socket.State.Open);
-            Assert.AreEqual(1, onOpenCount);
-        }
-    }
+			socket.Connect(string.Format("ws://{0}/socket", host), null);
+			Assert.IsTrue(socket.state == Socket.State.Open);
+			Assert.AreEqual(1, onOpenCount);
+		}
+	}
 }
 

--- a/PhoenixTests/PhoenixTests.csproj
+++ b/PhoenixTests/PhoenixTests.csproj
@@ -1,5 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -7,6 +9,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PhoenixTests</RootNamespace>
     <AssemblyName>PhoenixTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -17,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -25,14 +32,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\Vendor\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\Vendor\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="websocket-sharp">
       <HintPath>..\Vendor\websocket-sharp.dll</HintPath>
@@ -44,6 +52,8 @@
     <Compile Include="TimerTests.cs" />
     <Compile Include="IntegrationTests.cs" />
     <Compile Include="ReplySerializationTests.cs" />
+    <Compile Include="WebSocketImpl\DotNetWebSocket.cs" />
+    <Compile Include="WebSocketImpl\WebSocketSharp.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -52,4 +62,14 @@
       <Name>Phoenix</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+  </Target>
 </Project>

--- a/PhoenixTests/WebSocketImpl/WebSocketSharp.cs
+++ b/PhoenixTests/WebSocketImpl/WebSocketSharp.cs
@@ -1,0 +1,86 @@
+﻿using Phoenix;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WebSocketSharp;
+
+namespace PhoenixTests
+{
+    public sealed class WebsocketSharpAdapter : IWebsocket
+    {
+
+        private readonly WebSocket ws;
+        private readonly WebsocketConfiguration config;
+
+
+        public WebsocketSharpAdapter(WebSocket ws, WebsocketConfiguration config)
+        {
+
+            this.ws = ws;
+            this.config = config;
+
+            ws.OnOpen += OnWebsocketOpen;
+            ws.OnClose += OnWebsocketClose;
+            ws.OnError += OnWebsocketError;
+            ws.OnMessage += OnWebsocketMessage;
+        }
+
+
+        #region IWebsocket methods
+
+        public void Connect()
+        {
+            ws.Connect();
+        }
+
+        public void Send(string message)
+        {
+            ws.Send(message);
+        }
+
+        public void Close(ushort? code = null, string message = null)
+        {
+            ws.Close();
+        }
+
+        #endregion
+
+
+        #region websocketsharp callbacks
+
+        public void OnWebsocketOpen(object sender, EventArgs args)
+        {
+            config.onOpenCallback(this);
+        }
+
+        public void OnWebsocketClose(object sender, CloseEventArgs args)
+        {
+            config.onCloseCallback(this, args.Code, args.Reason);
+        }
+
+        public void OnWebsocketError(object sender, ErrorEventArgs args)
+        {
+            config.onErrorCallback(this, args.Message);
+        }
+
+        public void OnWebsocketMessage(object sender, MessageEventArgs args)
+        {
+            config.onMessageCallback(this, args.Data);
+        }
+
+        #endregion
+    }
+
+    public sealed class WebsocketSharpFactory : IWebsocketFactory
+    {
+
+        public IWebsocket Build(WebsocketConfiguration config)
+        {
+
+            var socket = new WebSocket(config.uri.AbsoluteUri);
+            return new WebsocketSharpAdapter(socket, config);
+        }
+    }
+}

--- a/PhoenixTests/WebSocketImpl/WebSocketSharp.cs
+++ b/PhoenixTests/WebSocketImpl/WebSocketSharp.cs
@@ -8,79 +8,79 @@ using WebSocketSharp;
 
 namespace PhoenixTests
 {
-    public sealed class WebsocketSharpAdapter : IWebsocket
-    {
+	public sealed class WebsocketSharpAdapter : IWebsocket
+	{
 
-        private readonly WebSocket ws;
-        private readonly WebsocketConfiguration config;
-
-
-        public WebsocketSharpAdapter(WebSocket ws, WebsocketConfiguration config)
-        {
-
-            this.ws = ws;
-            this.config = config;
-
-            ws.OnOpen += OnWebsocketOpen;
-            ws.OnClose += OnWebsocketClose;
-            ws.OnError += OnWebsocketError;
-            ws.OnMessage += OnWebsocketMessage;
-        }
+		private readonly WebSocket ws;
+		private readonly WebsocketConfiguration config;
 
 
-        #region IWebsocket methods
+		public WebsocketSharpAdapter(WebSocket ws, WebsocketConfiguration config)
+		{
 
-        public void Connect()
-        {
-            ws.Connect();
-        }
+			this.ws = ws;
+			this.config = config;
 
-        public void Send(string message)
-        {
-            ws.Send(message);
-        }
-
-        public void Close(ushort? code = null, string message = null)
-        {
-            ws.Close();
-        }
-
-        #endregion
+			ws.OnOpen += OnWebsocketOpen;
+			ws.OnClose += OnWebsocketClose;
+			ws.OnError += OnWebsocketError;
+			ws.OnMessage += OnWebsocketMessage;
+		}
 
 
-        #region websocketsharp callbacks
+		#region IWebsocket methods
 
-        public void OnWebsocketOpen(object sender, EventArgs args)
-        {
-            config.onOpenCallback(this);
-        }
+		public void Connect()
+		{
+			ws.Connect();
+		}
 
-        public void OnWebsocketClose(object sender, CloseEventArgs args)
-        {
-            config.onCloseCallback(this, args.Code, args.Reason);
-        }
+		public void Send(string message)
+		{
+			ws.Send(message);
+		}
 
-        public void OnWebsocketError(object sender, ErrorEventArgs args)
-        {
-            config.onErrorCallback(this, args.Message);
-        }
+		public void Close(ushort? code = null, string message = null)
+		{
+			ws.Close();
+		}
 
-        public void OnWebsocketMessage(object sender, MessageEventArgs args)
-        {
-            config.onMessageCallback(this, args.Data);
-        }
+		#endregion
 
-        #endregion
-    }
 
-    public sealed class WebsocketSharpFactory : IWebsocketFactory
-    {
+		#region websocketsharp callbacks
 
-        public IWebsocket Build(WebsocketConfiguration config)
-        {
+		public void OnWebsocketOpen(object sender, EventArgs args)
+		{
+			config.onOpenCallback(this);
+		}
 
-            var socket = new WebSocket(config.uri.AbsoluteUri);
-            return new WebsocketSharpAdapter(socket, config);
-        }
-    }
+		public void OnWebsocketClose(object sender, CloseEventArgs args)
+		{
+			config.onCloseCallback(this, args.Code, args.Reason);
+		}
+
+		public void OnWebsocketError(object sender, ErrorEventArgs args)
+		{
+			config.onErrorCallback(this, args.Message);
+		}
+
+		public void OnWebsocketMessage(object sender, MessageEventArgs args)
+		{
+			config.onMessageCallback(this, args.Data);
+		}
+
+		#endregion
+	}
+
+	public sealed class WebsocketSharpFactory : IWebsocketFactory
+	{
+
+		public IWebsocket Build(WebsocketConfiguration config)
+		{
+
+			var socket = new WebSocket(config.uri.AbsoluteUri);
+			return new WebsocketSharpAdapter(socket, config);
+		}
+	}
 }

--- a/PhoenixTests/WebSocketImpl/dotNetWebSocket.cs
+++ b/PhoenixTests/WebSocketImpl/dotNetWebSocket.cs
@@ -9,133 +9,133 @@ using System.Threading.Tasks;
 
 namespace PhoenixTests
 {
-    public sealed class DotNetWebSocketAdapter : IWebsocket
-    {
+	public sealed class DotNetWebSocketAdapter : IWebsocket
+	{
 
-        private readonly ClientWebSocket ws;
-        private readonly WebsocketConfiguration config;
-        private UTF8Encoding encoder = new UTF8Encoding();
-        private const int receiveChunkSize = 1024;
-        private Task<WebSocketReceiveResult> receiveTask;
-        private bool async;
+		private readonly ClientWebSocket ws;
+		private readonly WebsocketConfiguration config;
+		private UTF8Encoding encoder = new UTF8Encoding();
+		private const int receiveChunkSize = 1024;
+		private Task<WebSocketReceiveResult> receiveTask;
+		private bool async;
 
-        public DotNetWebSocketAdapter(ClientWebSocket ws, WebsocketConfiguration config, bool async = false)
-        {
-            this.ws = ws;
-            this.config = config;
-            this.async = async;
-        }
+		public DotNetWebSocketAdapter(ClientWebSocket ws, WebsocketConfiguration config, bool async = false)
+		{
+			this.ws = ws;
+			this.config = config;
+			this.async = async;
+		}
 
-        #region IWebsocket methods
+		#region IWebsocket methods
 
-        public void Connect()
-        {
-            try
-            {
-                var task = this.ws.ConnectAsync(config.uri, CancellationToken.None);
-                task.Wait();
-                receiveTask = Receive();
+		public void Connect()
+		{
+			try
+			{
+				var task = this.ws.ConnectAsync(config.uri, CancellationToken.None);
+				task.Wait();
+				receiveTask = Receive();
 
-                this.config.onOpenCallback(this);
-            }
-            catch (Exception ex)
-            {
-                this.config.onErrorCallback(this, ex.Message);
-            }
-        }
+				this.config.onOpenCallback(this);
+			}
+			catch (Exception ex)
+			{
+				this.config.onErrorCallback(this, ex.Message);
+			}
+		}
 
-        public void Send(string message)
-        {
-            if (!SendMessage(message))
-                return;
+		public void Send(string message)
+		{
+			if (!SendMessage(message))
+				return;
 
-            if (!async)
-            {
-                try
-                {
-                    this.receiveTask.Wait();
-                }
-                catch (Exception e)
-                {
-                    this.config.onErrorCallback(this, e.Message);
-                    return;
-                }
-            }
-        }
+			if (!async)
+			{
+				try
+				{
+					this.receiveTask.Wait();
+				}
+				catch (Exception e)
+				{
+					this.config.onErrorCallback(this, e.Message);
+					return;
+				}
+			}
+		}
 
-        private async Task<WebSocketReceiveResult> Receive()
-        {
-            byte[] buffer = new byte[receiveChunkSize];
-            var result = await this.ws.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-            if (result.MessageType == WebSocketMessageType.Close)
-            {
-                await this.ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
-            }
-            else
-            {
-                this.config.onMessageCallback(this, System.Text.Encoding.Default.GetString(buffer));
-                this.receiveTask = Receive();
-            }
-            return result;
-        }
+		private async Task<WebSocketReceiveResult> Receive()
+		{
+			byte[] buffer = new byte[receiveChunkSize];
+			var result = await this.ws.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+			if (result.MessageType == WebSocketMessageType.Close)
+			{
+				await this.ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+			}
+			else
+			{
+				this.config.onMessageCallback(this, System.Text.Encoding.Default.GetString(buffer));
+				this.receiveTask = Receive();
+			}
+			return result;
+		}
 
-        private bool SendMessage(string message)
-        {
+		private bool SendMessage(string message)
+		{
 
-            //byte[] buffer = encoder.GetBytes("{\"op\":\"blocks_sub\"}"); //"{\"op\":\"unconfirmed_sub\"}");
-            byte[] buffer = encoder.GetBytes(message);
+			//byte[] buffer = encoder.GetBytes("{\"op\":\"blocks_sub\"}"); //"{\"op\":\"unconfirmed_sub\"}");
+			byte[] buffer = encoder.GetBytes(message);
 
-            if (this.ws.State == WebSocketState.Open)
-            {
-                this.ws.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
-                return true;
-            }
-            else
-            {
-                this.config.onErrorCallback(this, "Could not send message because websocket is closed.");
-                return false;
-            }
-        }
+			if (this.ws.State == WebSocketState.Open)
+			{
+				this.ws.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
+				return true;
+			}
+			else
+			{
+				this.config.onErrorCallback(this, "Could not send message because websocket is closed.");
+				return false;
+			}
+		}
 
-        public void Close(ushort? code = null, string message = null)
-        {
-            WebSocketCloseStatus status;
-            Task closeTask;
+		public void Close(ushort? code = null, string message = null)
+		{
+			WebSocketCloseStatus status;
+			Task closeTask;
 
-            this.config.onCloseCallback(this, code ?? 0, message);
+			this.config.onCloseCallback(this, code ?? 0, message);
 
-            if (code.HasValue && Enum.TryParse<WebSocketCloseStatus>(code.ToString(), out status))
-            {
-                closeTask = this.ws.CloseAsync(status, message, CancellationToken.None);
-            }
-            else
-            {
-                closeTask = this.ws.CloseAsync(WebSocketCloseStatus.Empty, message, CancellationToken.None);
-            }
-            try
-            {
-                closeTask.Wait();
-            }
-            catch (Exception ex)
-            {
-                this.config.onErrorCallback(this, ex.Message);
-            }
-            finally
-            {
-                this.ws.Dispose();
-            }
+			if (code.HasValue && Enum.TryParse<WebSocketCloseStatus>(code.ToString(), out status))
+			{
+				closeTask = this.ws.CloseAsync(status, message, CancellationToken.None);
+			}
+			else
+			{
+				closeTask = this.ws.CloseAsync(WebSocketCloseStatus.Empty, message, CancellationToken.None);
+			}
+			try
+			{
+				closeTask.Wait();
+			}
+			catch (Exception ex)
+			{
+				this.config.onErrorCallback(this, ex.Message);
+			}
+			finally
+			{
+				this.ws.Dispose();
+			}
 
-        }
+		}
 
-        #endregion
-    }
+		#endregion
+	}
 
-    public sealed class DotNetWebSocketFactory : IWebsocketFactory
-    {
-        public IWebsocket Build(WebsocketConfiguration config)
-        {
-            var socket = new ClientWebSocket();
-            return new DotNetWebSocketAdapter(socket, config);
-        }
-    }
+	public sealed class DotNetWebSocketFactory : IWebsocketFactory
+	{
+		public IWebsocket Build(WebsocketConfiguration config)
+		{
+			var socket = new ClientWebSocket();
+			return new DotNetWebSocketAdapter(socket, config);
+		}
+	}
 }

--- a/PhoenixTests/WebSocketImpl/dotNetWebSocket.cs
+++ b/PhoenixTests/WebSocketImpl/dotNetWebSocket.cs
@@ -1,0 +1,141 @@
+﻿using Phoenix;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PhoenixTests
+{
+    public sealed class DotNetWebSocketAdapter : IWebsocket
+    {
+
+        private readonly ClientWebSocket ws;
+        private readonly WebsocketConfiguration config;
+        private UTF8Encoding encoder = new UTF8Encoding();
+        private const int receiveChunkSize = 1024;
+        private Task<WebSocketReceiveResult> receiveTask;
+        private bool async;
+
+        public DotNetWebSocketAdapter(ClientWebSocket ws, WebsocketConfiguration config, bool async = false)
+        {
+            this.ws = ws;
+            this.config = config;
+            this.async = async;
+        }
+
+        #region IWebsocket methods
+
+        public void Connect()
+        {
+            try
+            {
+                var task = this.ws.ConnectAsync(config.uri, CancellationToken.None);
+                task.Wait();
+                receiveTask = Receive();
+
+                this.config.onOpenCallback(this);
+            }
+            catch (Exception ex)
+            {
+                this.config.onErrorCallback(this, ex.Message);
+            }
+        }
+
+        public void Send(string message)
+        {
+            if (!SendMessage(message))
+                return;
+
+            if (!async)
+            {
+                try
+                {
+                    this.receiveTask.Wait();
+                }
+                catch (Exception e)
+                {
+                    this.config.onErrorCallback(this, e.Message);
+                    return;
+                }
+            }
+        }
+
+        private async Task<WebSocketReceiveResult> Receive()
+        {
+            byte[] buffer = new byte[receiveChunkSize];
+            var result = await this.ws.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await this.ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+            }
+            else
+            {
+                this.config.onMessageCallback(this, System.Text.Encoding.Default.GetString(buffer));
+                this.receiveTask = Receive();
+            }
+            return result;
+        }
+
+        private bool SendMessage(string message)
+        {
+
+            //byte[] buffer = encoder.GetBytes("{\"op\":\"blocks_sub\"}"); //"{\"op\":\"unconfirmed_sub\"}");
+            byte[] buffer = encoder.GetBytes(message);
+
+            if (this.ws.State == WebSocketState.Open)
+            {
+                this.ws.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
+                return true;
+            }
+            else
+            {
+                this.config.onErrorCallback(this, "Could not send message because websocket is closed.");
+                return false;
+            }
+        }
+
+        public void Close(ushort? code = null, string message = null)
+        {
+            WebSocketCloseStatus status;
+            Task closeTask;
+
+            this.config.onCloseCallback(this, code ?? 0, message);
+
+            if (code.HasValue && Enum.TryParse<WebSocketCloseStatus>(code.ToString(), out status))
+            {
+                closeTask = this.ws.CloseAsync(status, message, CancellationToken.None);
+            }
+            else
+            {
+                closeTask = this.ws.CloseAsync(WebSocketCloseStatus.Empty, message, CancellationToken.None);
+            }
+            try
+            {
+                closeTask.Wait();
+            }
+            catch (Exception ex)
+            {
+                this.config.onErrorCallback(this, ex.Message);
+            }
+            finally
+            {
+                this.ws.Dispose();
+            }
+
+        }
+
+        #endregion
+    }
+
+    public sealed class DotNetWebSocketFactory : IWebsocketFactory
+    {
+        public IWebsocket Build(WebsocketConfiguration config)
+        {
+            var socket = new ClientWebSocket();
+            return new DotNetWebSocketAdapter(socket, config);
+        }
+    }
+}

--- a/PhoenixTests/packages.config
+++ b/PhoenixTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.11.0" targetFramework="net462" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net462" />
+</packages>


### PR DESCRIPTION
In order to write a test case I added my own implementation for the IWebsocket and IWebsocketFactory Interface using the .net websockets. With this implementation I was able to receive the response in the same method call where the message is send. 
I was not able to create a deterministic test case for this issue with the websocketshap implementation because it is not possible to wait for the response.

During writting the test case I stumbled over another issue. When you call disconnect() on the socket the state is set to closed before the close method on the actual websocket is called so WebsocketOnClose(IWebsocket ws, ushort code, string message) returns immediatly because the socket is already closed. This caused an error because the socket never called OnClose() an I could not count the open connections correctly in my test case. I had this issue with both implementations of the websockets.